### PR TITLE
Move common Metal objects into base example class

### DIFF
--- a/source/base/Example.cpp
+++ b/source/base/Example.cpp
@@ -28,6 +28,37 @@ Example::Example(const char *title, uint32_t width, uint32_t height) {
     CurrentClockTimestamp = SDL_GetPerformanceCounter();
     Width = width;
     Height = height;
+
+
+    Device = NS::TransferPtr(MTL::CreateSystemDefaultDevice());
+
+    auto *layer = static_cast<CA::MetalLayer *>((SDL_Metal_GetLayer(View)));
+    layer->setDevice(Device.get());
+
+    CommandQueue = NS::TransferPtr(Device->newCommandQueue());
+
+    CreateDepthStencil();
+
+    // Load Pipeline Library
+    CFBundleRef main_bundle = CFBundleGetMainBundle();
+    CFURLRef url = CFBundleCopyResourcesDirectoryURL(main_bundle);
+    char cwd[PATH_MAX];
+    CFURLGetFileSystemRepresentation(url, TRUE, (UInt8 *) cwd, PATH_MAX);
+    CFRelease(url);
+    auto path = NS::Bundle::mainBundle()->resourcePath();
+    NS::String *library = path->stringByAppendingString(
+            NS::String::string("/default.metallib", NS::ASCIIStringEncoding));
+
+    NS::Error *error = nullptr;
+    PipelineLibrary = NS::TransferPtr(Device->newLibrary(library, &error));
+    if (error != nullptr) {
+        fprintf(stderr, "Failed to create pipeline library: %s\n",
+                error->localizedFailureReason()->utf8String());
+        abort();
+    }
+
+
+    FrameSemaphore = dispatch_semaphore_create(BUFFER_COUNT);
 }
 
 Example::~Example() {
@@ -35,6 +66,28 @@ Example::~Example() {
         SDL_DestroyWindow(Window);
     }
     SDL_Quit();
+}
+
+void Example::CreateDepthStencil() {
+    MTL::DepthStencilDescriptor *depthStencilDescriptor = MTL::DepthStencilDescriptor::alloc()->init();
+    depthStencilDescriptor->setDepthCompareFunction(MTL::CompareFunctionLess);
+    depthStencilDescriptor->setDepthWriteEnabled(true);
+
+    DepthStencilState = NS::TransferPtr(Device->newDepthStencilState(depthStencilDescriptor));
+
+    depthStencilDescriptor->release();
+
+
+    MTL::TextureDescriptor *textureDescriptor = MTL::TextureDescriptor::texture2DDescriptor(
+            MTL::PixelFormatDepth32Float_Stencil8, GetFrameWidth(), GetFrameHeight(), false);
+    textureDescriptor->setSampleCount(1);
+    textureDescriptor->setUsage(MTL::TextureUsageRenderTarget);
+    textureDescriptor->setResourceOptions(MTL::ResourceOptionCPUCacheModeDefault | MTL::ResourceStorageModePrivate);
+    textureDescriptor->setStorageMode(MTL::StorageModeMemoryless);
+
+    DepthStencilTexture = NS::TransferPtr(Device->newTexture(textureDescriptor));
+
+    textureDescriptor->release();
 }
 
 uint32_t Example::GetFrameWidth() const {
@@ -56,6 +109,8 @@ int Example::Run([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
     }
 
     while (Running) {
+        NS::AutoreleasePool *pool = NS::AutoreleasePool::alloc()->init();
+
         SDL_Event e;
         SDL_PollEvent(&e);
         if (e.type == SDL_QUIT) {
@@ -78,7 +133,23 @@ int Example::Run([[maybe_unused]] int argc, [[maybe_unused]] char **argv) {
 
         Update(elapsed);
 
-        Render(elapsed);
+        FrameIndex = (FrameIndex + 1) % BUFFER_COUNT;
+
+        MTL::CommandBuffer *commandBuffer = CommandQueue->commandBuffer();
+
+        dispatch_semaphore_wait(FrameSemaphore, DISPATCH_TIME_FOREVER);
+        commandBuffer->addCompletedHandler([this](MTL::CommandBuffer *buffer) {
+            dispatch_semaphore_signal(FrameSemaphore);
+        });
+
+        auto *layer = static_cast<CA::MetalLayer *>(SDL_Metal_GetLayer(View));
+        CA::MetalDrawable *drawable = layer->nextDrawable();
+        if (drawable) {
+            Render(drawable, elapsed);
+        }
+
+
+        pool->release();
     }
 
     return EXIT_SUCCESS;

--- a/source/base/Example.hpp
+++ b/source/base/Example.hpp
@@ -6,6 +6,9 @@
 
 #include <SDL2/SDL.h>
 
+#include <Metal/Metal.hpp>
+#include <QuartzCore/QuartzCore.hpp>
+
 class Example {
 public:
     Example(const char *title, uint32_t width, uint32_t height);
@@ -22,10 +25,24 @@ public:
 
     virtual void Update(float elapsed) = 0;
 
-    virtual void Render(float elapsed) = 0;
+    virtual void Render(CA::MetalDrawable *drawable, float elapsed) = 0;
 
 protected:
+    static constexpr int BUFFER_COUNT = 3;
+
     SDL_MetalView View;
+
+    // Metal
+    NS::SharedPtr<MTL::Device> Device;
+    NS::SharedPtr<MTL::CommandQueue> CommandQueue;
+    NS::SharedPtr<MTL::Texture> DepthStencilTexture;
+    NS::SharedPtr<MTL::DepthStencilState> DepthStencilState;
+    NS::SharedPtr<MTL::Library> PipelineLibrary;
+
+    // Sync primitives
+    uint32_t FrameIndex = 0;
+    dispatch_semaphore_t FrameSemaphore;
+
 private:
     SDL_Window *Window;
     uint32_t Width;
@@ -33,4 +50,9 @@ private:
     uint64_t LastClockTimestamp;
     uint64_t CurrentClockTimestamp;
     bool Running;
+
+
+    void CreateDepthStencil();;
+
+
 };

--- a/source/instancing/instancing.cpp
+++ b/source/instancing/instancing.cpp
@@ -28,7 +28,6 @@ XM_ALIGNED_STRUCT(16) InstanceData {
 };
 
 class Instancing : public Example {
-    static constexpr int BUFFER_COUNT = 3;
     static constexpr int INSTANCE_COUNT = 3;
 public:
     Instancing();
@@ -39,30 +38,22 @@ public:
 
     void Update(float elapsed) override;
 
-    void Render(float elapsed) override;
+    void Render(CA::MetalDrawable *drawable, float elapsed) override;
 
 private:
-    void CreateDepthStencil();
-
     void CreateBuffers();
 
     void CreatePipelineState();
 
     void UpdateUniforms();
 
-    NS::SharedPtr<MTL::Device> Device;
-    NS::SharedPtr<MTL::CommandQueue> CommandQueue;
-    NS::SharedPtr<MTL::Texture> DepthStencilTexture;
-    NS::SharedPtr<MTL::DepthStencilState> DepthStencilState;
     NS::SharedPtr<MTL::RenderPipelineState> PipelineState;
-    NS::SharedPtr<MTL::Library> PipelineLibrary;
     NS::SharedPtr<MTL::Buffer> VertexBuffer;
     NS::SharedPtr<MTL::Buffer> IndexBuffer;
     NS::SharedPtr<MTL::Buffer> InstanceBuffer[BUFFER_COUNT];
     std::unique_ptr<Camera> MainCamera;
 
-    uint32_t FrameIndex = 0;
-    dispatch_semaphore_t FrameSemaphore;
+
     float RotationX = 0.0f;
     float RotationY = 0.0f;
 };
@@ -72,16 +63,9 @@ Instancing::Instancing()
 
 }
 
-Instancing::~Instancing() {
-
-}
+Instancing::~Instancing() = default;
 
 bool Instancing::Load() {
-    Device = NS::TransferPtr(MTL::CreateSystemDefaultDevice());
-
-    auto *layer = static_cast<CA::MetalLayer *>((SDL_Metal_GetLayer(View)));
-    layer->setDevice(Device.get());
-
     const auto width = GetFrameWidth();
     const auto height = GetFrameHeight();
     const float aspect = (float) width / (float) height;
@@ -94,15 +78,10 @@ bool Instancing::Load() {
                                           XMFLOAT3{0.0f, 1.0f, 0.0f},
                                           fov, aspect, near, far);
 
-    CommandQueue = NS::TransferPtr(Device->newCommandQueue());
-
-    CreateDepthStencil();
 
     CreateBuffers();
 
     CreatePipelineState();
-
-    FrameSemaphore = dispatch_semaphore_create(BUFFER_COUNT);
 
     return true;
 }
@@ -112,102 +91,45 @@ void Instancing::Update(float elapsed) {
     RotationY += elapsed;
 }
 
-void Instancing::Render(float elapsed) {
-    NS::AutoreleasePool *pool = NS::AutoreleasePool::alloc()->init();
-
-    FrameIndex = (FrameIndex + 1) % BUFFER_COUNT;
-
-    MTL::CommandBuffer *commandBuffer = CommandQueue->commandBuffer();
-
-    dispatch_semaphore_wait(FrameSemaphore, DISPATCH_TIME_FOREVER);
-    commandBuffer->addCompletedHandler([this](MTL::CommandBuffer *buffer) {
-        dispatch_semaphore_signal(FrameSemaphore);
-    });
+void Instancing::Render(CA::MetalDrawable *drawable, float elapsed) {
 
     UpdateUniforms();
 
-    CA::MetalLayer *layer = (CA::MetalLayer *) (SDL_Metal_GetLayer(View));
-    CA::MetalDrawable *drawable = layer->nextDrawable();
-    if (drawable) {
-        auto texture = drawable->texture();
+    MTL::CommandBuffer *commandBuffer = CommandQueue->commandBuffer();
 
-        MTL::RenderPassDescriptor *passDescriptor = MTL::RenderPassDescriptor::renderPassDescriptor();
-        passDescriptor->colorAttachments()->object(0)->setTexture(texture);
-        passDescriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionClear);
-        passDescriptor->colorAttachments()->object(0)->setStoreAction(MTL::StoreActionStore);
-        passDescriptor->colorAttachments()->object(0)->setClearColor(MTL::ClearColor(.39, .58, .92, 1.0));
-        passDescriptor->depthAttachment()->setTexture(DepthStencilTexture.get());
-        passDescriptor->depthAttachment()->setLoadAction(MTL::LoadActionClear);
-        passDescriptor->depthAttachment()->setStoreAction(MTL::StoreActionDontCare);
-        passDescriptor->depthAttachment()->setClearDepth(1.0);
-        passDescriptor->stencilAttachment()->setTexture(DepthStencilTexture.get());
-        passDescriptor->stencilAttachment()->setLoadAction(MTL::LoadActionClear);
-        passDescriptor->stencilAttachment()->setStoreAction(MTL::StoreActionDontCare);
-        passDescriptor->stencilAttachment()->setClearStencil(0);
+    auto texture = drawable->texture();
 
-        MTL::RenderCommandEncoder *commandEncoder = commandBuffer->renderCommandEncoder(passDescriptor);
-        commandEncoder->setRenderPipelineState(PipelineState.get());
-        commandEncoder->setDepthStencilState(DepthStencilState.get());
-        commandEncoder->setFrontFacingWinding(MTL::WindingCounterClockwise);
-        commandEncoder->setCullMode(MTL::CullModeNone);
+    MTL::RenderPassDescriptor *passDescriptor = MTL::RenderPassDescriptor::renderPassDescriptor();
+    passDescriptor->colorAttachments()->object(0)->setTexture(texture);
+    passDescriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionClear);
+    passDescriptor->colorAttachments()->object(0)->setStoreAction(MTL::StoreActionStore);
+    passDescriptor->colorAttachments()->object(0)->setClearColor(MTL::ClearColor(.39, .58, .92, 1.0));
+    passDescriptor->depthAttachment()->setTexture(DepthStencilTexture.get());
+    passDescriptor->depthAttachment()->setLoadAction(MTL::LoadActionClear);
+    passDescriptor->depthAttachment()->setStoreAction(MTL::StoreActionDontCare);
+    passDescriptor->depthAttachment()->setClearDepth(1.0);
+    passDescriptor->stencilAttachment()->setTexture(DepthStencilTexture.get());
+    passDescriptor->stencilAttachment()->setLoadAction(MTL::LoadActionClear);
+    passDescriptor->stencilAttachment()->setStoreAction(MTL::StoreActionDontCare);
+    passDescriptor->stencilAttachment()->setClearStencil(0);
 
-        const size_t alignedUniformSize = (sizeof(Uniforms) + 0xFF) & -0x100;
-        const auto uniformBufferOffset =
-                alignedUniformSize * FrameIndex;
+    MTL::RenderCommandEncoder *commandEncoder = commandBuffer->renderCommandEncoder(passDescriptor);
+    commandEncoder->setRenderPipelineState(PipelineState.get());
+    commandEncoder->setDepthStencilState(DepthStencilState.get());
+    commandEncoder->setFrontFacingWinding(MTL::WindingCounterClockwise);
+    commandEncoder->setCullMode(MTL::CullModeNone);
+    commandEncoder->setVertexBuffer(VertexBuffer.get(), 0, 0);
+    commandEncoder->setVertexBuffer(InstanceBuffer[FrameIndex].get(), 0, 1);
+    commandEncoder->drawIndexedPrimitives(MTL::PrimitiveTypeTriangle,
+                                          IndexBuffer->length() / sizeof(uint16_t), MTL::IndexTypeUInt16,
+                                          IndexBuffer.get(), 0, INSTANCE_COUNT);
+    commandEncoder->endEncoding();
 
-        commandEncoder->setVertexBuffer(VertexBuffer.get(), 0, 0);
-        commandEncoder->setVertexBuffer(InstanceBuffer[FrameIndex].get(), 0, 1);
-
-
-        commandEncoder->drawIndexedPrimitives(MTL::PrimitiveTypeTriangle,
-                                              IndexBuffer->length() / sizeof(uint16_t), MTL::IndexTypeUInt16,
-                                              IndexBuffer.get(), 0, INSTANCE_COUNT);
-
-        commandEncoder->endEncoding();
-
-        commandBuffer->presentDrawable(drawable);
-        commandBuffer->commit();
-    }
-
-    pool->release();
-}
-
-void Instancing::CreateDepthStencil() {
-    MTL::DepthStencilDescriptor *depthStencilDescriptor = MTL::DepthStencilDescriptor::alloc()->init();
-    depthStencilDescriptor->setDepthCompareFunction(MTL::CompareFunctionLess);
-    depthStencilDescriptor->setDepthWriteEnabled(true);
-
-    DepthStencilState = NS::TransferPtr(Device->newDepthStencilState(depthStencilDescriptor));
-
-    depthStencilDescriptor->release();
-
-
-    MTL::TextureDescriptor *textureDescriptor = MTL::TextureDescriptor::texture2DDescriptor(
-            MTL::PixelFormatDepth32Float_Stencil8, GetFrameWidth(), GetFrameHeight(), false);
-    textureDescriptor->setSampleCount(1);
-    textureDescriptor->setUsage(MTL::TextureUsageRenderTarget);
-    textureDescriptor->setResourceOptions(MTL::ResourceOptionCPUCacheModeDefault | MTL::ResourceStorageModePrivate);
-    textureDescriptor->setStorageMode(MTL::StorageModeMemoryless);
-
-    DepthStencilTexture = NS::TransferPtr(Device->newTexture(textureDescriptor));
-
-    textureDescriptor->release();
+    commandBuffer->presentDrawable(drawable);
+    commandBuffer->commit();
 }
 
 void Instancing::CreatePipelineState() {
-    CFBundleRef main_bundle = CFBundleGetMainBundle();
-    CFURLRef url = CFBundleCopyResourcesDirectoryURL(main_bundle);
-    char cwd[PATH_MAX];
-    CFURLGetFileSystemRepresentation(url, TRUE, (UInt8 *) cwd, PATH_MAX);
-    CFRelease(url);
-    auto path = NS::Bundle::mainBundle()->resourcePath();
-    NS::String *library = path->stringByAppendingString(
-            NS::String::string("/default.metallib", NS::ASCIIStringEncoding));
-    NS::Error *error = nullptr;
-
-    auto std_str = library->utf8String();
-    PipelineLibrary = NS::TransferPtr(Device->newLibrary(library, &error));
-
     MTL::VertexDescriptor *vertexDescriptor = MTL::VertexDescriptor::alloc()->init();
 
     // Position
@@ -242,6 +164,7 @@ void Instancing::CreatePipelineState() {
             PipelineLibrary->newFunction(NS::String::string("instancing_fragment", NS::ASCIIStringEncoding)));
     pipelineDescriptor->setVertexDescriptor(vertexDescriptor);
 
+    NS::Error *error = nullptr;
     PipelineState = NS::TransferPtr(Device->newRenderPipelineState(pipelineDescriptor, &error));
     if (error) {
         fprintf(stderr, "Failed to create pipeline state object: %s\n",
@@ -292,9 +215,9 @@ void Instancing::CreateBuffers() {
 void Instancing::UpdateUniforms() {
     MTL::Buffer *instanceBuffer = InstanceBuffer[FrameIndex].get();
 
-    InstanceData *instanceData = (InstanceData *) instanceBuffer->contents();
+    auto *instanceData = static_cast<InstanceData *>( instanceBuffer->contents());
     for (auto index = 0; index < INSTANCE_COUNT; ++index) {
-        auto translation = XMFLOAT3(-5.0f + (index * 5.0f), 0.0f, -10.0f);
+        auto translation = XMFLOAT3(-5.0f + (5.0f * (float) index), 0.0f, -10.0f);
         auto rotationX = RotationX;
         auto rotationY = RotationY;
         auto scaleFactor = 1.0f;


### PR DESCRIPTION
This commit moves the common shared Metal objects into the base example class to avoid cluttering each sample with the same device and sync object creation code. Now, samples all have access to the device, command queue, sync objects, depth stencil buffer. The swapchain image for the active frame is passed directly to the render call as a parameter.