### PR TITLE
Update to use CA::MetalDisplayLink for synchronizing display

### DIFF
--- a/source/base/Example.hpp
+++ b/source/base/Example.hpp
@@ -15,11 +15,12 @@
 #include "Keyboard.hpp"
 #include "Mouse.hpp"
 
-class Example
+class Example : public CA::MetalDisplayLinkDelegate
 {
 public:
 
 	SDL_Window* Window;
+
 	Example(const char* title, uint32_t width, uint32_t height);
 
 	virtual ~Example();
@@ -46,6 +47,9 @@ public:
 
 	void AnimationRender(float elapsed);
 
+	void metalDisplayLinkNeedsUpdate(CA::MetalDisplayLink* displayLink, CA::MetalDisplayLinkUpdate* update) override;
+
+
 protected:
 	static constexpr int BufferCount = 3;
 
@@ -56,6 +60,7 @@ protected:
 	std::unique_ptr<class Mouse> Mouse;
 
 	// Metal
+	NS::SharedPtr<CA::MetalDisplayLink> DisplayLink_;
 	NS::SharedPtr<MTL::Device> Device;
 	NS::SharedPtr<MTL::CommandQueue> CommandQueue;
 	NS::SharedPtr<MTL::Texture> DepthStencilTexture;


### PR DESCRIPTION
This commit updates the examples to leverage the CA::MetalDisplayLink to sync the rendering to the display refresh across iOS, iPadOS, and macOS. Note: This requires at least macOS 14, iOS 17, iPadOS 17, and tvOS 17 to work. All samples will only run on those platforms target OS versions going forward.